### PR TITLE
Add self-test of /.well-known dispatch rules.

### DIFF
--- a/appengine/handleSelfTest.go
+++ b/appengine/handleSelfTest.go
@@ -1,0 +1,14 @@
+package appengine
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/log"
+)
+
+func handleSelfTest(c context.Context, w http.ResponseWriter, r *http.Request) error {
+	log.Infof(c, "Self test successful!")
+	http.Error(w, "I'm a teapot!", 418)
+	return nil
+}

--- a/appengine/handleStatus.go
+++ b/appengine/handleStatus.go
@@ -87,6 +87,9 @@ func handleStatus(c context.Context, w http.ResponseWriter, r *http.Request) err
 		return err
 	}, func() error {
 		acmeTest = selfTest(c, r)
+		if acmeTest != nil {
+			log.Errorf(c, "Self-test for ACME challenge path failed: %v", err)
+		}
 		return nil
 	}); err != nil {
 		return err
@@ -219,12 +222,10 @@ func selfTest(c context.Context, r *http.Request) error {
 	client := urlfetch.Client(c)
 	resp, err := client.Get(u.String())
 	if err != nil {
-		log.Errorf(c, "Self-test for ACME challenge path failed: %v", err)
 		return fmt.Errorf("Self-test for ACME challenge path failed: %v", err)
 	}
 	if resp.StatusCode != 418 { // I'm a teapot!
-		log.Errorf(c, "Expected self-test response 418 but was: %d", resp.StatusCode)
-		return fmt.Errorf("/.well-known/acme-challenge is not correctly mapped to this app")
+		return fmt.Errorf("Expected self-test resposne 418 but was: %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/appengine/handleStatus.go
+++ b/appengine/handleStatus.go
@@ -5,7 +5,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
-	"runtime"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -39,19 +39,13 @@ func handleStatus(c context.Context, w http.ResponseWriter, r *http.Request) err
 		return fmt.Errorf("No service account found for project %s: %v", project, err)
 	}
 
-	acmeTest := selfTest(c, r)
-	// The self test starts another request within the same go app. Because
-	// GOMAXPROCS is set to 1 on AppEngine, this causes a deadlock as the url
-	// fetch in this goroutine blocks and the other request never gets
-	// scheduled.
-	runtime.Gosched()
-
 	// Lookup everything we need in parallel.
 	certs := map[string]*aeapi.AuthorizedCertificate{}
 	ops := map[string]*CreateOperation{}
 	authorizedDomains := map[string]struct{}{}
 	var domainMappings []*aeapi.DomainMapping
 	var account *RegisteredAccount
+	var acmeTest error
 
 	if err := parallel.Parallel(nil, nil, func() error {
 		// Get certificates on this project.
@@ -91,6 +85,9 @@ func handleStatus(c context.Context, w http.ResponseWriter, r *http.Request) err
 		var err error
 		ops, err = GetRecentCreateOperations(c)
 		return err
+	}, func() error {
+		acmeTest = selfTest(c, r)
+		return nil
 	}); err != nil {
 		return err
 	}
@@ -209,12 +206,18 @@ func isAuthorizedSubdomain(domain string, authorized map[string]struct{}) bool {
 	}
 }
 
+// selfTest checks that the ACME challenge path (/.well-known/acme-challenge) is
+// actually mapped to this module.
 func selfTest(c context.Context, r *http.Request) error {
-	// Self test ACME challenge prefix is correctly mapped to us.
-	url := *r.URL
-	url.Path = selfTestPrefix
+	log.Infof(c, "Request URL: %s", r.URL.String())
+	u := &url.URL{
+		Path:   selfTestPrefix,
+		Host:   appengine.DefaultVersionHostname(c),
+		Scheme: "http",
+	}
+	log.Infof(c, "New URL: %s", u.String())
 	client := urlfetch.Client(c)
-	resp, err := client.Get(url.String())
+	resp, err := client.Get(u.String())
 	if err != nil {
 		log.Errorf(c, "Self-test for ACME challenge path failed: %v", err)
 		return fmt.Errorf("Self-test for ACME challenge path failed: %v", err)

--- a/appengine/handleStatus.go
+++ b/appengine/handleStatus.go
@@ -211,7 +211,7 @@ func isAuthorizedSubdomain(domain string, authorized map[string]struct{}) bool {
 func selfTest(c context.Context, r *http.Request) error {
 	log.Infof(c, "Request URL: %s", r.URL.String())
 	u := &url.URL{
-		Path:   selfTestPrefix,
+		Path:   selfTestPath,
 		Host:   appengine.DefaultVersionHostname(c),
 		Scheme: "http",
 	}

--- a/appengine/main.go
+++ b/appengine/main.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	challengePathPrefix = "/.well-known/acme-challenge/"
+	selfTestPrefix      = challengePathPrefix + "self-test"
 )
 
 func init() {
@@ -14,4 +15,5 @@ func init() {
 	http.HandleFunc("/ssl-certificates/delete", wrapHTTPHandler(handleDelete))
 	http.HandleFunc("/ssl-certificates/status", wrapHTTPHandler(handleStatus))
 	http.HandleFunc(challengePathPrefix, wrapHTTPHandler(handleChallenge))
+	http.HandleFunc(selfTestPrefix, wrapHTTPHandler(handleSelfTest))
 }

--- a/appengine/main.go
+++ b/appengine/main.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	challengePathPrefix = "/.well-known/acme-challenge/"
-	selfTestPrefix      = challengePathPrefix + "self-test"
+	selfTestPath        = challengePathPrefix + "self-test"
 )
 
 func init() {
@@ -15,5 +15,5 @@ func init() {
 	http.HandleFunc("/ssl-certificates/delete", wrapHTTPHandler(handleDelete))
 	http.HandleFunc("/ssl-certificates/status", wrapHTTPHandler(handleStatus))
 	http.HandleFunc(challengePathPrefix, wrapHTTPHandler(handleChallenge))
-	http.HandleFunc(selfTestPrefix, wrapHTTPHandler(handleSelfTest))
+	http.HandleFunc(selfTestPath, wrapHTTPHandler(handleSelfTest))
 }

--- a/appengine/status.html
+++ b/appengine/status.html
@@ -112,7 +112,8 @@ p.bg-warning {
 {% if acmeTestFailed %}
 <p class="bg-warning">
   The path <code>/.well-known/acme-challenge/*</code> is not correctly mapped to
-  this app. Make sure your <code>dispatch.yaml</code> is correct.
+  this app. <a href="https://github.com/hatstand/gacertsbot/blob/master/appengine/README.md">
+    Make sure your <code>dispatch.yaml</code> is correct</a>.
 </p>
 {% endif %}
 

--- a/appengine/status.html
+++ b/appengine/status.html
@@ -109,6 +109,13 @@ p.bg-warning {
 </p>
 {% endif %}
 
+{% if acmeTestFailed %}
+<p class="bg-warning">
+  The path <code>/.well-known/acme-challenge/*</code> is not correctly mapped to
+  this app. Make sure your <code>dispatch.yaml</code> is correct.
+</p>
+{% endif %}
+
 {% if unusedCerts %}
   <div class="unused">
     <span class="h1">


### PR DESCRIPTION
Having to explicitly yield with `runtime.Gosched()` seems bonkers to me but otherwise the self-test request was timing out after the default 5s.